### PR TITLE
fix(package): Update dependencies to "lodash.throttle": "4.1.1" 

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "eslint --fix ./src"
   },
   "dependencies": {
-    "lodash": "4.17.10"
+    "lodash.throttle": "4.1.1"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/autoScroll.js
+++ b/src/autoScroll.js
@@ -1,4 +1,4 @@
-import _throttle from 'lodash/throttle';
+import _throttle from 'lodash.throttle';
 
 const setup = () => {
     const autoScrollCtrl = {};


### PR DESCRIPTION
 - Since the source code applies `lodash.throttle` only, there is no need to set the entire `lodash` into dependencies.  
- May resolve #2 too